### PR TITLE
Add uuid v4 command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+uuid

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ Required Go version 1.13+
 ### Installation
 Run the following command
 ```bash
- git clone git@github.com:samit22/uuid.git
+ go get github.com/samit22/uuid
 
- go install uuid
+ go install github.com/samit22/uuid
 
  uuid
  ```

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -33,10 +33,10 @@ var rootCmd = &cobra.Command{
 	Short: "Command line interface to generate uuid",
 	Long: `It provides command line interface to generate uuid or list of uuids.
 
-	Supported Version: v3 and v4
+	Supported Version: v4
 	`,
 
-	Run: func(cmd *cobra.Command, args []string) { fmt.Println("Welcome to UUID CLI  --@samit22`") },
+	Run: func(cmd *cobra.Command, args []string) { fmt.Println("Welcome to UUID CLI  BY: github.com/samit22`") },
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.
@@ -49,6 +49,8 @@ func Execute() {
 }
 
 func init() {
+
+	rootCmd.AddCommand(v4Cmd)
 
 	cobra.OnInitialize(initConfig)
 

--- a/cmd/v4.go
+++ b/cmd/v4.go
@@ -1,0 +1,100 @@
+/*
+Copyright © 2020 NAME HERE <EMAIL ADDRESS>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"uuid/generator"
+
+	"github.com/spf13/cobra"
+)
+
+//generator interface to interact with uuid generator
+type GeneratorV4 interface {
+	V4() string
+}
+
+// v4Cmd represents the v4 command
+var v4Cmd = &cobra.Command{
+	Use:   "v4",
+	Short: "Generate uuid v4",
+	Long: `Generated v4 uuid:
+
+By default single uuid is generated.
+Multiple uuids is generated giving the argument the number of uuids to generate.
+Example: uuid v4 10
+`,
+	Run: func(cmd *cobra.Command, args []string) {
+		ug := generator.Generate{}
+		generateUUIDV4(args, ug)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(v4Cmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// v4Cmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// v4Cmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}
+
+func generateUUIDV4(args []string, g GeneratorV4) (uuids []string, err error) {
+	var (
+		num = 1
+		msg = "UUID"
+	)
+	if len(args) != 0 {
+		n := args[0]
+		num, err = strconv.Atoi(n)
+		if err != nil {
+			errMsg := "Argument must a integer, please enter number between 1 to 100"
+			fmt.Println(errMsg)
+			err = errors.New(errMsg)
+			return
+		}
+		if num < 1 || num > 100 {
+			errMsg := "Please enter number between 1 to 100"
+			fmt.Println(errMsg)
+			err = errors.New(errMsg)
+			return
+		}
+	}
+	if num > 1 {
+		msg = "UUIDS"
+	}
+	fmt.Printf("Generating %d %s \n \n", num, msg)
+
+	uuids = generate(num, g)
+	fmt.Println(strings.Join(uuids, "\n"))
+	return
+}
+
+func generate(n int, g GeneratorV4) (res []string) {
+	res = make([]string, n)
+	for i := 0; i < n; i++ {
+		res[i] = g.V4()
+	}
+	return
+}

--- a/cmd/v4.go
+++ b/cmd/v4.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2020 NAME HERE <EMAIL ADDRESS>
+Copyright © 2020 Samit samitghimire@gmail.com>
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//generator interface to interact with uuid generator
+//GeneratorV4 interface to interact with uuid generator
 type GeneratorV4 interface {
 	V4() string
 }

--- a/cmd/v4_test.go
+++ b/cmd/v4_test.go
@@ -1,0 +1,79 @@
+package cmd
+
+import "testing"
+
+type mockUUID struct {
+}
+
+func (m mockUUID) V4() string {
+	return "0000000-0000-0000-0000-000000000000"
+}
+
+func TestGenerateUUIDv4(t *testing.T) {
+
+	t.Log("When argument contains non integer field")
+	{
+		arg := []string{"abc"}
+		m := mockUUID{}
+		t.Run("Returns non integer error", func(t *testing.T) {
+
+			_, err := generateUUIDV4(arg, m)
+			if err == nil {
+				t.Errorf("expected error but didn't receive one")
+			}
+			expErrMsg := "Argument must a integer, please enter number between 1 to 100"
+			if err.Error() != expErrMsg {
+				t.Errorf("Expected %s got %s", expErrMsg, err.Error())
+			}
+		})
+	}
+
+	t.Log("When argument is not between 1 to 100")
+	{
+		arg := []string{"101"}
+		m := mockUUID{}
+		t.Run("Returns range error", func(t *testing.T) {
+
+			_, err := generateUUIDV4(arg, m)
+			if err == nil {
+				t.Errorf("expected error but didn't receive one")
+			}
+			expErrMsg := "Please enter number between 1 to 100"
+			if err.Error() != expErrMsg {
+				t.Errorf("Expected %s got %s", expErrMsg, err.Error())
+			}
+		})
+	}
+
+	t.Log("When argument is not given")
+	{
+		arg := []string{}
+		m := mockUUID{}
+		t.Run("Returns one uuid", func(t *testing.T) {
+
+			uuids, err := generateUUIDV4(arg, m)
+			if err != nil {
+				t.Errorf("unexpected error occured %+v", err)
+			}
+			if len(uuids) != 1 {
+				t.Errorf("Expected 1 uuid got %d", len(uuids))
+			}
+		})
+	}
+
+	t.Log("When argument is between 1 to 100")
+	{
+		arg := []string{"50"}
+		m := mockUUID{}
+		t.Run("Returns one uuid", func(t *testing.T) {
+
+			uuids, err := generateUUIDV4(arg, m)
+			if err != nil {
+				t.Errorf("unexpected error occured %+v", err)
+			}
+			if len(uuids) != 50 {
+				t.Errorf("Expected 50 uuids got %d", len(uuids))
+			}
+		})
+	}
+}

--- a/generator/uuidv4.go
+++ b/generator/uuidv4.go
@@ -1,0 +1,24 @@
+package generator
+
+import (
+	"fmt"
+
+	uuidg "github.com/gofrs/uuid"
+)
+
+// Generator provides interface to generate uuid
+type Generator interface {
+	V4() string
+}
+
+// Generate struct to call the uuid methods
+type Generate struct{}
+
+// V4 create a new uuid in v4 format
+func (g Generate) V4() string {
+	u, err := uuidg.NewV4()
+	if err != nil {
+		fmt.Println("Something went wrong while generating uuid")
+	}
+	return u.String()
+}

--- a/generator/uuidv4_test.go
+++ b/generator/uuidv4_test.go
@@ -1,0 +1,19 @@
+package generator
+
+import (
+	"regexp"
+	"testing"
+)
+
+func TestGenerateV4(t *testing.T) {
+	var uuidPattern = "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+	t.Run("Return uuid v4", func(t *testing.T) {
+		g := Generate{}
+		uuid := g.V4()
+		re := regexp.MustCompile(uuidPattern)
+		if !re.MatchString(uuid) {
+			t.Errorf("invalid uuid genereated")
+		}
+	})
+
+}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module uuid
 go 1.13
 
 require (
+	github.com/gofrs/uuid v3.3.0+incompatible
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/viper v1.7.1

--- a/go.sum
+++ b/go.sum
@@ -47,6 +47,9 @@ github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/gofrs/uuid v1.2.0 h1:coDhrjgyJaglxSjxuJdqQSSdUpG3w6p1OwN2od6frBU=
+github.com/gofrs/uuid v3.3.0+incompatible h1:8K4tyRfvU1CYPgJsveYFQMhpFd/wXNM7iK6rR7UHz84=
+github.com/gofrs/uuid v3.3.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=


### PR DESCRIPTION
Fixes: https://github.com/samit22/uuid/issues/2
Added v4 command.

Usages:
``` bash
uuid v4   # Returns single uuid
uuid v4 10 #  Returns 10 uuids
```