### PR TITLE
Add command to generate empty/nil UUID

### DIFF
--- a/cmd/empty.go
+++ b/cmd/empty.go
@@ -1,0 +1,23 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// empty represents command generating empty UUID.
+var empty = &cobra.Command{
+	Use:     "empty",
+	Aliases: []string{"nil"},
+	Short:   "Generate empty uuid",
+	Long: `Generate empty:
+
+Generates empty (all-zeroes) uuid
+`,
+	Run: func(cmd *cobra.Command, args []string) {
+		const emptyUUID = "00000000-0000-0000-0000-000000000000"
+
+		fmt.Println(emptyUUID)
+	},
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -51,6 +51,7 @@ func Execute() {
 func init() {
 
 	rootCmd.AddCommand(v4Cmd)
+	rootCmd.AddCommand(empty)
 
 	cobra.OnInitialize(initConfig)
 

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,11 @@
+package main
+
+import "os"
+
+func ExampleGenerateEmpty() {
+	// Pass argument to test 'uuid empty' command.
+	os.Args = append(os.Args, "empty")
+
+	main()
+	// Output: 00000000-0000-0000-0000-000000000000
+}


### PR DESCRIPTION
Fixes https://github.com/samit22/uuid/issues/9.

Adding a testable example may be controversial so feel free to reject this part. I just assumed that testing it in any other way would not make much sense, since you chose to use `fmt.Println` in other places to write to the console directly, the only way I can think of testing this would be introducing yet another abstractio level and generate empty UUID there (and test that function). Seemed like an overkill, but you're the boss here 😉 